### PR TITLE
adding a way to lock certain actions so they can only be done once at the same time.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -65,6 +65,11 @@ services:
         - '@user'
         - '@eru.nczone.db'
 
+    eru.nczone.zone.locks:
+      class: eru\nczone\zone\locks
+      arguments:
+        - '@eru.nczone.db'
+
     eru.nczone.zone.matches:
       class: eru\nczone\zone\matches
       arguments:

--- a/migrations/install_db_create.php
+++ b/migrations/install_db_create.php
@@ -190,6 +190,18 @@ class install_db_create extends \phpbb\db\migration\migration
                     ],
                     'PRIMARY_KEY' => ['user_id', 'setting'],
                 ],
+                $this->table_prefix . 'zone_locks' => [
+                    'COLUMNS' => [
+                        'hash' => ['CHAR:32'],
+                        'payload' => ['TEXT', null],
+                        'created' => ['TIMESTAMP', 0],
+                        'expires' => ['TIMESTAMP', 0],
+                    ],
+                    'PRIMARY_KEY' => ['hash'],
+                    'KEYS' => [
+                        'created' => ['INDEX', 'created'],
+                    ],
+                ],
             ],
             'add_index' => [
                 $this->table_prefix . 'zone_match_players' => [

--- a/tests/utility/db_test.php
+++ b/tests/utility/db_test.php
@@ -97,6 +97,14 @@ class db_test extends \phpbb_database_test_case
                 'SELECT',
                 [
                     'FROM' => ['phpbb_civs_table' => 'x'],
+                    'WHERE' => ['civ_id' => ['$gt' => 5, '$lt' => 9]],
+                ],
+                'SELECT * FROM phpbb_civs_table x WHERE `civ_id` > 5 AND `civ_id` < 9'
+            ],
+            [
+                'SELECT',
+                [
+                    'FROM' => ['phpbb_civs_table' => 'x'],
                     'WHERE' => ['civ_id' => [1, 5]],
                 ],
                 'SELECT * FROM phpbb_civs_table x WHERE `civ_id` IN (1,5)'

--- a/utility/db.php
+++ b/utility/db.php
@@ -49,6 +49,8 @@ class db
     public $draw_players_table;
     /** @var string */
     public $user_settings_table;
+    /** @var string */
+    public $locks_table;
 
     private const FMT_MAP = [
         '$like' => '%s LIKE %s',
@@ -88,6 +90,7 @@ class db
         $this->draw_process_table = $table_prefix . 'zone_draw_process';
         $this->draw_players_table = $table_prefix . 'zone_draw_players';
         $this->user_settings_table = $table_prefix . 'zone_user_settings';
+        $this->locks_table = $table_prefix . 'zone_locks';
     }
 
     /**
@@ -190,9 +193,15 @@ class db
         return $row ? \reset($row) : null;
     }
 
+    public function insert_only(string $table, array $data)
+    {
+        $dataSql = $this->db->sql_build_array('INSERT', $data);
+        return $this->db->sql_query("INSERT INTO {$table} {$dataSql}");
+    }
+
     public function insert(string $table, array $data): int
     {
-        $this->db->sql_query('INSERT INTO ' . $table . ' ' . $this->db->sql_build_array('INSERT', $data));
+        $this->insert_only($table, $data);
         // we cast the insert id to int, ignoring the fact that driver_interface returns strings
         // the id should be a ctype int though, so cast should be alright
         return (int)$this->db->sql_nextid();
@@ -206,6 +215,11 @@ class db
             'UPDATE ' . $table
             . ' SET ' . $this->db->sql_build_array('UPDATE', $data) .
             $whereSql);
+    }
+
+    public function txn_fn(callable $func)
+    {
+        return $this->run_txn($func);
     }
 
     public function run_txn(callable $func)
@@ -323,5 +337,18 @@ class db
             }
         }
         return \implode(' AND ', $wheres);
+    }
+
+    public function delete(string $table, array $where): bool
+    {
+        $whereSql = $this->build_where($where);
+        $whereSql = $whereSql ? " WHERE {$whereSql}" : '';
+        $this->db->sql_query("DELETE FROM {$table}{$whereSql}");
+        return $this->db->sql_affectedrows() !== false;
+    }
+
+    public function sql_return_on_error(bool $fail)
+    {
+        return $this->db->sql_return_on_error($fail);
     }
 }

--- a/utility/db.php
+++ b/utility/db.php
@@ -217,9 +217,11 @@ class db
             $whereSql);
     }
 
-    public function txn_fn(callable $func)
+    public function txn_fn(callable $func): callable
     {
-        return $this->run_txn($func);
+        return function () use ($func) {
+            return $this->run_txn($func);
+        };
     }
 
     public function run_txn(callable $func)

--- a/utility/zone_util.php
+++ b/utility/zone_util.php
@@ -4,6 +4,7 @@ namespace eru\nczone\utility;
 
 use eru\nczone\zone\civs;
 use eru\nczone\zone\bets;
+use eru\nczone\zone\locks;
 use eru\nczone\zone\maps;
 use eru\nczone\zone\players;
 use eru\nczone\zone\matches;
@@ -91,5 +92,15 @@ class zone_util
             $misc = phpbb_util::container()->get('eru.nczone.zone.misc');
         }
         return $misc;
+    }
+
+    public static function locks(): locks
+    {
+        static $locks;
+        if ($locks === null) {
+            /** @var locks $locks */
+            $locks = phpbb_util::container()->get('eru.nczone.zone.locks');
+        }
+        return $locks;
     }
 }

--- a/zone/error/UnableToAquireLockError.php
+++ b/zone/error/UnableToAquireLockError.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace eru\nczone\zone\error;
+
+class UnableToAquireLockError extends \Exception
+{
+}

--- a/zone/locks.php
+++ b/zone/locks.php
@@ -16,7 +16,7 @@ class locks
     }
 
     /**
-     * Aquire a lock, then call $fn, then release the lock.
+     * Aquire lock, then call $fn, then release lock.
      *
      * The lock hash is calculated from the given $payload. If $timeout_sec
      * is greater than 0, the lock is released (ignored) after this
@@ -55,7 +55,7 @@ class locks
     }
 
     /**
-     * Aquire lock for a given hash.
+     * Aquire lock for given hash.
      *
      * Payload is saved for easier debugging in case something goes wrong..
      *
@@ -88,7 +88,7 @@ class locks
     }
 
     /**
-     * Release the lock identified by the given hash if it expired before $time.
+     * Release lock for given hash if it expired before $time.
      *
      * @param string $hash
      * @param $time
@@ -102,7 +102,7 @@ class locks
     }
 
     /**
-     * Release the lock identified by the given hash.
+     * Release lock for given hash.
      *
      * @param string $hash
      */

--- a/zone/locks.php
+++ b/zone/locks.php
@@ -79,7 +79,7 @@ class locks
             'hash' => $hash,
             'payload' => $payloadStr,
             'created' => $now,
-            'expires' => $timeout_sec,
+            'expires' => $timeout_sec ? $now + $timeout_sec : 0,
         ]);
         $this->db->sql_return_on_error(false);
         if (!$inserted) {

--- a/zone/locks.php
+++ b/zone/locks.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace eru\nczone\zone;
+
+use eru\nczone\utility\db;
+use eru\nczone\zone\error\UnableToAquireLockError;
+
+class locks
+{
+    /** @var db */
+    private $db;
+
+    public function __construct(db $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * Aquire a lock, then call $fn, then release the lock.
+     *
+     * The lock hash is calculated from the given $payload. If $timeoutSec
+     * is greater than 0, the lock is released (ignored) after this
+     * many seconds.
+     *
+     * @param mixed $payload
+     * @param callable $fn
+     * @param int $timeoutSec
+     *
+     * @return mixed
+     * @throws UnableToAquireLockError
+     */
+    public function runExclusive($payload, callable $fn, int $timeoutSec = 0)
+    {
+        $hash = $this->hash($payload);
+
+        $this->aquire($hash, $payload, $timeoutSec);
+
+        $ret = $fn();
+
+        $this->release($hash);
+
+        return $ret;
+    }
+
+    /**
+     * Return hash over all parameters.
+     *
+     * @param mixed ...$params
+     *
+     * @return string
+     */
+    private function hash(...$params): string
+    {
+        return \md5(\serialize($params));
+    }
+
+    /**
+     * Aquire lock for a given hash.
+     *
+     * Payload is saved for easier debugging in case something goes wrong..
+     *
+     * @param string $hash
+     * @param mixed $payload
+     * @param int $timeoutSec
+     *
+     * @throws UnableToAquireLockError
+     */
+    private function aquire(string $hash, $payload, int $timeoutSec): void
+    {
+        $now = \time();
+
+        $this->releaseExpired($hash, $now);
+
+        $payloadStr = \json_encode($payload);
+        // hash is the unique key, so the insert fails when there is already
+        // an entry in the table. when that happens, we throw an exception
+        $this->db->sql_return_on_error(true);
+        $inserted = $this->db->insert_only($this->db->locks_table, [
+            'hash' => $hash,
+            'payload' => $payloadStr,
+            'created' => $now,
+            'expires' => $timeoutSec,
+        ]);
+        $this->db->sql_return_on_error(false);
+        if (!$inserted) {
+            throw new UnableToAquireLockError("{$payloadStr} ({$hash})");
+        }
+    }
+
+    /**
+     * Release the lock identified by the given hash if it expired before $time.
+     *
+     * @param string $hash
+     * @param $time
+     */
+    private function releaseExpired(string $hash, int $time): void
+    {
+        $this->db->delete($this->db->locks_table, [
+            'hash' => $hash,
+            'expires' => ['$gt' => 0, '$lt' => $time]
+        ]);
+    }
+
+    /**
+     * Release the lock identified by the given hash.
+     *
+     * @param string $hash
+     */
+    private function release(string $hash): void
+    {
+        // releases all locks by a hash
+        $this->db->delete($this->db->locks_table, [
+            'hash' => $hash,
+        ]);
+    }
+}

--- a/zone/locks.php
+++ b/zone/locks.php
@@ -18,22 +18,22 @@ class locks
     /**
      * Aquire a lock, then call $fn, then release the lock.
      *
-     * The lock hash is calculated from the given $payload. If $timeoutSec
+     * The lock hash is calculated from the given $payload. If $timeout_sec
      * is greater than 0, the lock is released (ignored) after this
      * many seconds.
      *
      * @param mixed $payload
      * @param callable $fn
-     * @param int $timeoutSec
+     * @param int $timeout_sec
      *
      * @return mixed
      * @throws UnableToAquireLockError
      */
-    public function runExclusive($payload, callable $fn, int $timeoutSec = 0)
+    public function runExclusive($payload, callable $fn, int $timeout_sec = 0)
     {
         $hash = $this->hash($payload);
 
-        $this->aquire($hash, $payload, $timeoutSec);
+        $this->aquire($hash, $payload, $timeout_sec);
 
         $ret = $fn();
 
@@ -61,11 +61,11 @@ class locks
      *
      * @param string $hash
      * @param mixed $payload
-     * @param int $timeoutSec
+     * @param int $timeout_sec
      *
      * @throws UnableToAquireLockError
      */
-    private function aquire(string $hash, $payload, int $timeoutSec): void
+    private function aquire(string $hash, $payload, int $timeout_sec): void
     {
         $now = \time();
 
@@ -79,7 +79,7 @@ class locks
             'hash' => $hash,
             'payload' => $payloadStr,
             'created' => $now,
-            'expires' => $timeoutSec,
+            'expires' => $timeout_sec,
         ]);
         $this->db->sql_return_on_error(false);
         if (!$inserted) {


### PR DESCRIPTION
db transactions don't work, because they are committed too late. 
and locks on whole tables seem like overkill.

the new mechanism uses a table where locks are saved (1 row = 1 lock). if an unexpired entry is there, the code will throw an exception. the new mechanism should be used outside of transactions (see matches.php where it is used twice).  it does not check if we are currently in a transaction at them moment, could be added later.
hopefully fixes #23